### PR TITLE
logging: optional stdout logging

### DIFF
--- a/exoip.go
+++ b/exoip.go
@@ -26,7 +26,7 @@ var validate_config = flag.Bool("n", false, "Validate configuration and exit")
 var watch_mode = flag.Bool("W", false, "Watchdog mode")
 var associate_mode = flag.Bool("A", false, "Associate EIP and exit")
 var dissociate_mode = flag.Bool("D", false, "Dissociate EIP and exit")
-var log_stdout = flag.Bool("O", false, "Do not log to syslog, use standar output/error")
+var log_stdout = flag.Bool("O", false, "Do not log to syslog, use standard output")
 var peers stringslice
 var reset_peers bool = false
 

--- a/exoip.go
+++ b/exoip.go
@@ -26,6 +26,7 @@ var validate_config = flag.Bool("n", false, "Validate configuration and exit")
 var watch_mode = flag.Bool("W", false, "Watchdog mode")
 var associate_mode = flag.Bool("A", false, "Associate EIP and exit")
 var dissociate_mode = flag.Bool("D", false, "Dissociate EIP and exit")
+var log_stdout = flag.Bool("O", false, "Do not log to syslog, use standar output/error")
 var peers stringslice
 var reset_peers bool = false
 
@@ -182,7 +183,7 @@ func main() {
 	flag.Parse()
 
 	// Sanity Checks
-	exoip.SetupLogger()
+	exoip.SetupLogger(*log_stdout)
 	CheckConfiguration()
 
 	ego := egoscale.NewClient(*exo_endpoint, *exo_key, *exo_secret)

--- a/src/exoip/logging.go
+++ b/src/exoip/logging.go
@@ -18,7 +18,7 @@ func (l *WrappedLogger) Warning(msg string) {
 	if l.syslog {
 		l.syslog_writer.Warning(msg)
 	} else {
-		l.std_writer.Printf("WARNING: %s", msg)
+		l.std_writer.Printf("[WARNING] %s", msg)
 	}
 }
 
@@ -26,7 +26,7 @@ func (l *WrappedLogger) Crit(msg string) {
 	if l.syslog {
 		l.syslog_writer.Crit(msg)
 	} else {
-		l.std_writer.Printf("CRIT: %s", msg)
+		l.std_writer.Printf("[CRIT   ] %s", msg)
 	}
 }
 
@@ -34,14 +34,14 @@ func (l *WrappedLogger) Info(msg string) {
 	if l.syslog {
 		l.syslog_writer.Info(msg)
 	} else {
-		l.std_writer.Printf("INFO: %s", msg)
+		l.std_writer.Printf("[INFO   ] %s", msg)
 	}
 }
 
 func SetupLogger(log_stdout bool) {
 
 	if (log_stdout) {
-		logger := log.New(os.Stdout, "exoip", 0)
+		logger := log.New(os.Stdout, "exoip ", 0)
 		Logger = &WrappedLogger{syslog: false, std_writer: logger}
 	} else {
 		logger, err := syslog.New(syslog.LOG_DAEMON, "exoip")

--- a/src/exoip/logging.go
+++ b/src/exoip/logging.go
@@ -1,14 +1,51 @@
 package exoip
 
 import (
+	"os"
+	"log"
 	"log/syslog"
 )
 
-var Logger *syslog.Writer
+type WrappedLogger struct {
+	syslog bool
+	syslog_writer *syslog.Writer
+	std_writer *log.Logger
+}
 
-func SetupLogger() {
+var Logger *WrappedLogger
 
-	logger, err := syslog.New(syslog.LOG_DAEMON, "exoip")
-	AssertSuccess(err)
-	Logger = logger
+func (l *WrappedLogger) Warning(msg string) {
+	if l.syslog {
+		l.syslog_writer.Warning(msg)
+	} else {
+		l.std_writer.Printf("WARNING: %s", msg)
+	}
+}
+
+func (l *WrappedLogger) Crit(msg string) {
+	if l.syslog {
+		l.syslog_writer.Crit(msg)
+	} else {
+		l.std_writer.Printf("CRIT: %s", msg)
+	}
+}
+
+func (l *WrappedLogger) Info(msg string) {
+	if l.syslog {
+		l.syslog_writer.Info(msg)
+	} else {
+		l.std_writer.Printf("INFO: %s", msg)
+	}
+}
+
+func SetupLogger(log_stdout bool) {
+
+	if (log_stdout) {
+		logger := log.New(os.Stdout, "exoip", 0)
+		Logger = &WrappedLogger{syslog: false, std_writer: logger}
+	} else {
+		logger, err := syslog.New(syslog.LOG_DAEMON, "exoip")
+		AssertSuccess(err)
+		Logger = &WrappedLogger{syslog: true, syslog_writer: logger}
+	}
 }


### PR DESCRIPTION
Allow using stdout for logging. When running exoip in containers, this greatly simplifies the options for building and running (and opens the door to using the resulting binary in a `FROM scratch` image).