### PR TITLE
cmd: add -i option to specify instance ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ environment variable:
         Host priority (lowest wins) (default 10, maximum 255)
     -l string (or IF_BIND_ADDRESS)
         Address to bind to (default ":12345")
+    -i string (or IF_EXOSCALE_INSTANCE_ID)
+        Instance ID of one self (useful when running from a container)
     -p string (or IF_EXOSCALE_PEERS)
         peers to communicate with (may be repeated and/or comma-separated)
     -G string (or IF_EXOSCALE_PEER_GROUP)

--- a/api.go
+++ b/api.go
@@ -8,13 +8,9 @@ import (
 	"github.com/exoscale/egoscale"
 )
 
-func FetchMyNic(ego *egoscale.Client, mserver string) (string, error) {
+func FetchMyNic(ego *egoscale.Client, instanceId string) (string, error) {
 
-	instance_id, err := FetchMetadata(mserver, "/latest/instance-id")
-	if err != nil {
-		return "", err
-	}
-	vm_info, err := ego.GetVirtualMachine(instance_id)
+	vm_info, err := ego.GetVirtualMachine(instanceId)
 	if err != nil {
 		return "", err
 	}
@@ -26,12 +22,7 @@ func FetchMyNic(ego *egoscale.Client, mserver string) (string, error) {
 
 func (engine *Engine) FetchNicAndVm() {
 
-	mserver, err := FindMetadataServer()
-	AssertSuccess(err)
-	instance_id, err := FetchMetadata(mserver, "/latest/instance-id")
-	AssertSuccess(err)
-
-	vm_info, err := engine.Exo.GetVirtualMachine(instance_id)
+	vm_info, err := engine.Exo.GetVirtualMachine(engine.InstanceID)
 	AssertSuccess(err)
 
 	if len(vm_info.Nic) < 1 {

--- a/engine.go
+++ b/engine.go
@@ -64,12 +64,10 @@ func UUIDToStr(uuidbuf []byte) string {
 	return hexuuid
 }
 
-func NewWatchdogEngine(client *egoscale.Client, ip string, interval int,
+func NewWatchdogEngine(client *egoscale.Client, ip, instance_id string, interval int,
 	prio int, dead_ratio int, peers []string) *Engine {
 
-	mserver, err := FindMetadataServer()
-	AssertSuccess(err)
-	nicid, err := FetchMyNic(client, mserver)
+	nicid, err := FetchMyNic(client, instance_id)
 	uuidbuf, err := StrToUUID(nicid)
 	AssertSuccess(err)
 	sendbuf := make([]byte, 24)
@@ -113,6 +111,7 @@ func NewWatchdogEngine(client *egoscale.Client, ip string, interval int,
 		NicId:       nicid,
 		ExoIP:       netip,
 		Exo:         client,
+		InstanceID:  instance_id,
 		InitHoldOff: CurrentTimeMillis() + (1000 * int64(dead_ratio) * int64(interval)) + SkewMillis,
 	}
 	for _, p := range peers {
@@ -121,7 +120,7 @@ func NewWatchdogEngine(client *egoscale.Client, ip string, interval int,
 	return &engine
 }
 
-func NewEngine(client *egoscale.Client, ip string) *Engine {
+func NewEngine(client *egoscale.Client, ip, instance_id string) *Engine {
 
 	netip := net.ParseIP(ip)
 	if netip == nil {
@@ -137,8 +136,9 @@ func NewEngine(client *egoscale.Client, ip string) *Engine {
 	}
 
 	engine := Engine{
-		ExoIP: netip,
-		Exo:   client,
+		ExoIP:      netip,
+		Exo:        client,
+		InstanceID: instance_id,
 	}
 	engine.FetchNicAndVm()
 	return &engine

--- a/types.go
+++ b/types.go
@@ -42,4 +42,5 @@ type Engine struct {
 	NicId       string
 	ExoIP       net.IP
 	Exo         *egoscale.Client
+	InstanceID  string
 }


### PR DESCRIPTION
Closes #19

```
$ docker run exoscale/exoip --help
Usage of ./exoip:
  -A    Associate EIP and exit
  -D    Dissociate EIP and exit
  -G string
        Exoscale Security Group to use to create list of peers
  -O    Do not log to syslog, use standard output
  -P int
        Host priority (lowest wins) (default 10)
  -W    Watchdog mode
  -i string
        Exoscale Instance ID of oneself
  -l string
        Address to bind to (default ":12345")
  -n    Validate configuration and exit
  -p value
        peers to communicate with
  -r int
        Dead ratio (default 3)
  -t int
        Advertisement interval in seconds (default 1)
  -v    Log additional information
  -xe string
        Exoscale API Endpoint (default "https://api.exoscale.ch/compute")
  -xi string
        Exoscale Elastic IP to watch over
  -xk string
        Exoscale API Key
  -xs string
        Exoscale API Secret

```

/cc @kufi