### PR TITLE
Goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+exoip
 build
 vendor
 .gopath

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,18 @@
+builds:
+  - main: cmd/exoip/main.go
+    binary: exoip
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+sign:
+  cmd: gpg
+  args: ["-a", "-u", "ops@exoscale.ch", "--detach-sign", "${artifact}"]
+  artifacts: all
+
+
+dist: build
+
+git:
+  short_hash: true

--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ $ echo -n "info" | nc -4u -w1 0.0.0.0 12345
 
 If you wish to inspect **exoip** and build it by yourself, you can install it by using `go get`.
 
-    go get -u github.com/exoscale/exoip/cmd/exoip
+    go get -d github.com/exoscale/exoip
+    cd $GOPATH/src/github.com/exoscale/exoip
+    dep ensure -vendor-only
+    make
 
 ### Updating
 


### PR DESCRIPTION
https://goreleaser.com/

```
$ goreleaser --snapshot | xclip
   • releasing using goreleaser dev...
   • loading config file       file=.goreleaser.yml
   • SETTING DEFAULTS FOR:
      • loading environment variables
      • snapshoting
      • releasing to GitHub
      • project name
      • creating archives
      • building binaries
      • creating Linux packages with fpm
      • creating Linux packages with nfpm
      • creating Linux packages with snapcraft
      • calculating checksums
      • signing artifacts
      • creating Docker images
      • releasing to Artifactory
      • releasing to s3
      • creating homebrew formula
      • creating Scoop Manifest
   • RUNNING BEFORE HOOKS
   • CHECKING ./DIST
   • GETTING AND VALIDATING GIT STATE
      • releasing v0.3.9, commit b95c45e
      • skipped                   reason=disabled during snapshot mode
   • WRITING EFFECTIVE CONFIG FILE
      • writing                   config=build/config.yaml
   • GENERATING CHANGELOG
      • skipped                   reason=not available for snapshots
   • LOADING ENVIRONMENT VARIABLES
      • skipped                   reason=publishing is disabled
   • BUILDING BINARIES
      • building                  binary=build/linux_amd64/exoip
      • added new artifact        name=exoip path=build/linux_amd64/exoip type=Binary
   • CREATING ARCHIVES
      • creating                  archive=build/exoip_SNAPSHOT-b95c45e_linux_amd64.tar.gz
      • added new artifact        name=exoip_SNAPSHOT-b95c45e_linux_amd64.tar.gz path=build/exoip_SNAPSHOT-b95c45e_linux_amd64.tar.gz type=UploadableArchive                                                                                                                               
   • CREATING LINUX PACKAGES WITH NFPM
      • skipped                   reason=no output formats configured
   • CREATING LINUX PACKAGES WITH SNAPCRAFT
      • skipped                   reason=no summary nor description were provided
   • CALCULATING CHECKSUMS
      • added new artifact        name=exoip_SNAPSHOT-b95c45e_checksums.txt path=build/exoip_SNAPSHOT-b95c45e_checksums.txt type=Checksum
      • checksumming              file=exoip_SNAPSHOT-b95c45e_linux_amd64.tar.gz
   • SIGNING ARTIFACTS
      • added new artifact        name=exoip_SNAPSHOT-b95c45e_linux_amd64.tar.gz.sig path=build/exoip_SNAPSHOT-b95c45e_linux_amd64.tar.gz.sig type=Signature                                                                                                                               
      • added new artifact        name=exoip_SNAPSHOT-b95c45e_checksums.txt.sig path=build/exoip_SNAPSHOT-b95c45e_checksums.txt.sig type=Signature                                                                                                                                         
   • CREATING DOCKER IMAGES
      • skipped                   reason=docker section is not configured
   • RELEASING TO ARTIFACTORY
      • skipped                   reason=artifactory section is not configured
   • RELEASING TO S3
   • RELEASING TO GITHUB
      • skipped                   reason=publishing is disabled
   • CREATING HOMEBREW FORMULA
      • skipped                   reason=brew section is not configured
   • CREATING SCOOP MANIFEST
      • skipped                   reason=scoop section is not configured
   • release succeeded after 0.82s

$ tree build 
build
├── config.yaml
├── exoip_SNAPSHOT-b95c45e_checksums.txt
├── exoip_SNAPSHOT-b95c45e_checksums.txt.asc
├── exoip_SNAPSHOT-b95c45e_linux_amd64.tar.gz
├── exoip_SNAPSHOT-b95c45e_linux_amd64.tar.gz.asc
└── linux_amd64
    └── exoip
```