### PR TITLE
engine: fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "github.com/exoscale/egoscale"
   packages = ["."]
-  revision = "432a702ab7d709538572f9a2a42eaf0ca0691698"
-  version = "v0.9.23"
+  revision = "caa6b3727b959d704dda224fb7a63fae3c14d8fb"
+  version = "v0.9.26"
 
 [[projects]]
   branch = "master"
@@ -32,7 +32,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "6f686a352de66814cdd080d970febae7767857a3"
+  revision = "c11f84a56e43e20a78cee75a7c034031ecf57d1f"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/cmd/exoip/main.go
+++ b/cmd/exoip/main.go
@@ -324,11 +324,13 @@ func main() {
 					exoip.Logger.Info("new priority: %d", prio)
 				}
 			default:
-				exoip.Logger.Info("releasing the Nic and stopping.")
-				fmt.Fprintln(os.Stderr, "releasing the Nic and stopping")
-				if err := engine.ReleaseMyNic(); err != nil {
-					exoip.Logger.Crit(err.Error())
-					os.Exit(1)
+				if engine.State == exoip.StateMaster {
+					exoip.Logger.Info("releasing the Nic and stopping.")
+					fmt.Fprintln(os.Stderr, "releasing the Nic and stopping")
+					if err := engine.ReleaseMyNic(); err != nil {
+						exoip.Logger.Crit(err.Error())
+						os.Exit(1)
+					}
 				}
 				os.Exit(0)
 			}

--- a/engine.go
+++ b/engine.go
@@ -481,7 +481,7 @@ func (engine *Engine) PeerIsNewlyDead(now time.Time, peer *Peer) bool {
 		if dead {
 			Logger.Info(fmt.Sprintf("peer %s last seen %s (%dms ago), considering dead.", peer.UDPAddr.IP, peer.LastSeen.Format(time.RFC3339), peerDiff/time.Millisecond))
 		} else {
-			Logger.Info(fmt.Sprintf("peer %s last seen %s (%dms ago), is now back alive.", peer.UDPAddr.IP, peer.LastSeen.Format(time.RFC3339), peerDiff/time.Millisecond))
+			Logger.Info(fmt.Sprintf("peer %s, is now back alive.", peer.UDPAddr.IP))
 		}
 		peer.Dead = dead
 		return dead

--- a/peer.go
+++ b/peer.go
@@ -26,6 +26,7 @@ func NewPeer(listenAddress string, raddr *net.UDPAddr, id, nicID string) *Peer {
 		VirtualMachineID: id,
 		UDPAddr:          raddr,
 		NicID:            nicID,
+		Dead:             true,
 		conn:             conn,
 	}
 }


### PR DESCRIPTION
- don't assume peers are alive at boot
- release the NIC only if we are Master

A new comer would kill the existing peers as it joins the group, and they fail to update their list of peers in time.