### PR TITLE
engine: allow sending pings to a different port

### DIFF
--- a/cmd/exoip/main.go
+++ b/cmd/exoip/main.go
@@ -14,11 +14,14 @@ import (
 	"github.com/exoscale/exoip"
 )
 
+// defaultPort used by exoip, can be changed via "-l"
+const defaultPort = 12345
+
 type stringslice []string
 
 var timer = flag.Int("t", 1, "Advertisement interval in seconds")
 var prio = flag.Int("P", 10, "Host priority (lowest wins)")
-var address = flag.String("l", fmt.Sprintf(":%d", exoip.DefaultPort), "Address to bind to")
+var address = flag.String("l", fmt.Sprintf(":%d", defaultPort), "Address to bind to")
 var deadRatio = flag.Int("r", 3, "Dead ratio")
 var exoToken = flag.String("xk", "", "Exoscale API Key")
 var exoSecret = flag.String("xs", "", "Exoscale API Secret")

--- a/engine.go
+++ b/engine.go
@@ -58,9 +58,13 @@ func NewEngineWatchdog(client *egoscale.Client, addr string, ip net.IP, instance
 		sendbuf[i+8] = b
 	}
 
+	serverAddr, err := net.ResolveUDPAddr("udp", addr)
+	assertSuccessOrExit(err)
+
 	engine := &Engine{
 		client:            client,
 		ListenAddress:     addr,
+		listenPort:        serverAddr.Port,
 		DeadRatio:         deadRatio,
 		Interval:          time.Duration(interval) * time.Second,
 		priority:          sendbuf[2],
@@ -113,8 +117,6 @@ func (engine *Engine) NetworkLoop() error {
 
 	serverConn, err := net.ListenUDP("udp", serverAddr)
 	assertSuccessOrExit(err)
-
-	engine.listenPort = serverAddr.Port
 
 	Logger.Info("listening on %s", serverAddr)
 	buf := make([]byte, payloadLength)

--- a/engine.go
+++ b/engine.go
@@ -11,9 +11,6 @@ import (
 	"github.com/exoscale/egoscale"
 )
 
-// DefaultPort used by exoip
-const DefaultPort = 12345
-
 // ProtoVersion version of the protocol
 const ProtoVersion = "0201"
 
@@ -111,15 +108,18 @@ func NewEngine(client *egoscale.Client, ipAddress net.IP, instanceID egoscale.UU
 
 // NetworkLoop starts the UDP server
 func (engine *Engine) NetworkLoop() error {
-	ServerAddr, err := net.ResolveUDPAddr("udp", engine.ListenAddress)
-	assertSuccessOrExit(err)
-	ServerConn, err := net.ListenUDP("udp", ServerAddr)
+	serverAddr, err := net.ResolveUDPAddr("udp", engine.ListenAddress)
 	assertSuccessOrExit(err)
 
-	Logger.Info("listening on %s", ServerAddr)
+	serverConn, err := net.ListenUDP("udp", serverAddr)
+	assertSuccessOrExit(err)
+
+	engine.listenPort = serverAddr.Port
+
+	Logger.Info("listening on %s", serverAddr)
 	buf := make([]byte, payloadLength)
 	for {
-		n, addr, err := ServerConn.ReadFromUDP(buf)
+		n, addr, err := serverConn.ReadFromUDP(buf)
 		if err != nil {
 			Logger.Crit("network server died")
 			os.Exit(1)
@@ -177,7 +177,7 @@ func (engine *Engine) PingPeers() error {
 
 // FetchPeer fetches a Peer from its IP address
 func (engine *Engine) FetchPeer(peerAddress string) (*Peer, error) {
-	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", peerAddress, DefaultPort))
+	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", peerAddress, engine.listenPort))
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +421,7 @@ func (engine *Engine) UpdatePeers() error {
 			key := ip.String()
 			if _, ok := engine.peers[key]; !ok {
 				// add peer
-				addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", key, DefaultPort))
+				addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", key, engine.listenPort))
 				if err != nil {
 					Logger.Warning(err.Error())
 					return err

--- a/types.go
+++ b/types.go
@@ -37,6 +37,7 @@ type wrappedLogger struct {
 // Engine represents the ExoIP engine structure
 type Engine struct {
 	client            *egoscale.Client
+	listenPort        int
 	ListenAddress     string
 	DeadRatio         int
 	Interval          time.Duration


### PR DESCRIPTION
Fixes #59 

- ~https://sos-ch-dk-2.exo.io/yoanyoan/exoip_SNAPSHOT-652f3c7_linux_amd64.tar.gz~
- https://sos-ch-dk-2.exo.io/yoanyoan/exoip_SNAPSHOT-dee7ec0_linux_amd64.tar.gz

```
7edf3a396ee3e3dec6c73f18f5838b3945c012cb3185c07fafa48ffb7948f572  exoip_SNAPSHOT-652f3c7_linux_amd64.tar.gz
d3cfa411c5041680f8cc1455f73d93ecfd20347d68de329675daf583c4a96cde  exoip_SNAPSHOT-dee7ec0_linux_amd64.tar.gz
```