### PR TITLE
jenkins: build docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 .travis.yml
 Dockerfile
 README.md
+build
 bin
 src
 pkg
-vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ RUN apk add --no-cache \
 
 FROM linuxkit/ca-certificates:v0.6
 
-LABEL org.label-schema.name="ExoIP" \
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL org.label-schema.build-date=${BUILD_DATE} \
+      org.label-schema.vcs-ref=${VCS_REF} \
+      org.label-schema.name="ExoIP" \
       org.label-schema.vendor="Exoscale" \
       org.label-schema.description="IP watchdog" \
       org.label-schema.url="https://github.com/exoscale/exoip" \

--- a/Dockerfile.exoscale
+++ b/Dockerfile.exoscale
@@ -1,12 +1,25 @@
 FROM registry.internal.exoscale.ch/exoscale/golang:1.11 as build
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+
 RUN mkdir -p /exoip
 ADD . /exoip
 WORKDIR /exoip
 
-RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -o exoip -ldflags "-s -w" cmd/exoip/main.go
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+RUN echo ${VERSION}
+RUN go build \
+        -mod vendor \
+        -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${VCS_REF}" \
+        github.com/exoscale/exoip/cmd/exoip
 
 FROM registry.internal.exoscale.ch/exoscale/ubuntu:bionic
+
+ARG BUILD_DATE
+ARG VCS_REF
 
 LABEL org.label-schema.build-date=${BUILD_DATE} \
       org.label-schema.name="ExoIP" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,6 +99,6 @@ def docker() {
     def version = tag.replaceAll(~/^v(?=\d)/, "")
     def ref = sh("git rev-parse HEAD")
     def date = sh('date -u +"%Y-%m-%dT%H:%m:%SZ"')
-    return docker.build("registry.internal.exoscale.ch/exoscale/exoip:" + tag, "--network=host --no-cache --build-arg VCS_REF=$ref --build-arg BUILD_DATE=$date --build-arg VERSION=$version .")
+    return docker.build("registry.internal.exoscale.ch/exoscale/exoip:" + tag, "-f Dockerfile.exoscale --network=host --no-cache --build-arg VCS_REF=$ref --build-arg BUILD_DATE=$date --build-arg VERSION=$version .")
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,8 @@ node {
   repo = "exoscale/exoip"
 
   try {
+    def image
+
     dir('src') {
       stage('SCM') {
         checkout scm
@@ -14,7 +16,7 @@ node {
       stage('gofmt') {
         gofmt()
       }
-      stage('Build') {
+      stage('build') {
         parallel (
           "go lint": {
             golint(repo, "cmd/exoip")
@@ -24,9 +26,15 @@ node {
           },
           "go install": {
             build("exoip")
-          }
+          },
+          "docker": {
+            image = docker()
+          },
         )
       }
+    }
+    stage('push') {
+      image.push()
     }
   } catch (err) {
     currentBuild.result = 'FAILURE'
@@ -81,5 +89,16 @@ def build(...bins) {
         sh "test -e /go/bin/${bin}"
       }
     }
+  }
+}
+
+def docker() {
+  docker.withRegistry('https://registry.internal.exoscale.ch') {
+    def branch = getGitBranch().replace("/", "-")
+    def tag = getGitTag() ?: (branch == "master" ? "latest" : branch)
+    def version = tag.replaceAll(~/^v(?=\d)/, "")
+    def ref = sh("git rev-parse HEAD")
+    def date = sh('date -u +"%Y-%m-%dT%H:%m:%SZ"')
+    return docker.build("registry.internal.exoscale.ch/exoscale/exoip:" + tag, "--network=host --no-cache --build-arg VCS_REF=$ref --build-arg BUILD_DATE=$date --build-arg VERSION=$version .")
   }
 }

--- a/cmd/exoip/main.go
+++ b/cmd/exoip/main.go
@@ -14,6 +14,12 @@ import (
 	"github.com/exoscale/exoip"
 )
 
+var (
+	// version is to be given at compile time
+	version = "dev"
+	commit  = "n/a"
+)
+
 type stringslice []string
 
 var timer = flag.Int("t", 1, "Advertisement interval in seconds")
@@ -227,7 +233,7 @@ func main() {
 	flag.Parse()
 
 	if *printVersion {
-		fmt.Printf("%v\n", exoip.Version)
+		fmt.Printf("%s (%s)\n", version, commit)
 		os.Exit(0)
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,0 @@
-package exoip
-
-// Version represents exoip version
-const Version = "0.4.1"


### PR DESCRIPTION
our *private* image wasn't built anymore. Also, we take advantage of the tags from to put the version into the build, either via [goreleaser](https://goreleaser.com/build/) or _Jenkins_.